### PR TITLE
Modified sampler with KSP only option

### DIFF
--- a/finite-element/sampler.c
+++ b/finite-element/sampler.c
@@ -147,8 +147,9 @@ static PetscErrorCode SampleOnGrid(MPI_Comm comm,Op op,const PetscInt M[3],const
 #endif
 
   PetscFunctionBegin;
-
-  ierr = PetscOptionsHasName(NULL,NULL,"-ksp_only",&ksp_only);CHKERRQ(ierr);
+  ierr = PetscOptionsBegin(comm,NULL,"KSP or FMG solver option",NULL);CHKERRQ(ierr);
+  ierr = PetscOptionsBool("-ksp_only","Solve with KSP only","",ksp_only,&ksp_only,NULL);CHKERRQ(ierr);
+  ierr = PetscOptionsEnd();CHKERRQ(ierr);
 
   ierr = OpGetFEDegree(op,&fedegree);CHKERRQ(ierr);
   ierr = OpGetDof(op,&dof);CHKERRQ(ierr);


### PR DESCRIPTION
Added a flag to the sampler for ksp_only

Ran against "sample -pc_type jacobi -ksp_type cg -pc_jacobi_type rowsum -ksp_rtol 1e-10 -local 50,10000 -repeat 3 -op_type project2affine -ksp_only"

Also, removed redundant OpSetAddQuadPts from sampler

The options for the ksp only work if they come before the options for sampler.