### PR TITLE
Additional Quad Pts Test

### DIFF
--- a/finite-element/fefas.c
+++ b/finite-element/fefas.c
@@ -2,6 +2,7 @@ static const char help[] = "Geometric multigrid solver for finite-element elasti
 
 #include "fefas.h"
 
+PetscErrorCode TestAddQuad(void);
 PetscErrorCode TestGrid(void);
 PetscErrorCode TestFESpace(void);
 PetscErrorCode TestFEGrad(void);
@@ -24,6 +25,7 @@ static PetscErrorCode ActionParse(int argc,char *argv[],PetscErrorCode (**action
   PetscFunctionBegin;
   *action = NULL;
 
+  ierr = PetscFunctionListAdd(&actionlist,"test-addquadpts",TestAddQuad);CHKERRQ(ierr);
   ierr = PetscFunctionListAdd(&actionlist,"test-grid",TestGrid);CHKERRQ(ierr);
   ierr = PetscFunctionListAdd(&actionlist,"test-fespace",TestFESpace);CHKERRQ(ierr);
   ierr = PetscFunctionListAdd(&actionlist,"test-fegrad",TestFEGrad);CHKERRQ(ierr);

--- a/finite-element/grid.c
+++ b/finite-element/grid.c
@@ -897,7 +897,7 @@ PetscErrorCode DMFEGetTensorEval(DM dm,PetscInt *P,PetscInt *Q,const PetscReal *
   ierr = DMGetApplicationContext(dm,&fe);CHKERRQ(ierr);
 
   *P = fe->degree + 1;
-  *Q = fe->degree + 1;
+  *Q = fe->degree + fe->addquadpts + 1;
   if (B) *B = fe->ref.B;
   if (D) *D = fe->ref.D;
   if (x) *x = fe->ref.x;

--- a/finite-element/sampler.c
+++ b/finite-element/sampler.c
@@ -258,6 +258,7 @@ PetscErrorCode RunSample() {
   ierr = PetscOptionsReal("-mintime","Minimum interval (in seconds) for repeatedly solving each problem size","",mintime,&mintime,NULL);CHKERRQ(ierr);
   two = 2;
   ierr = PetscOptionsIntArray("-smooth","V- and F-cycle pre,post smoothing","",smooth,&two,NULL);CHKERRQ(ierr);
+  addquadpts = 0;
   ierr = PetscOptionsInt("-add_quad_pts","Number of additional quadrature points","",addquadpts,&addquadpts,NULL);CHKERRQ(ierr);
   ierr = PetscOptionsEnd();CHKERRQ(ierr);
 


### PR DESCRIPTION
Created test to verify additional quadrature points. The function should return the error message "quadrature = [some number] expected 14.734482" when run with "test-addquadpts -add_quad_pts x" for any x < 198 and no message for any x > 197.